### PR TITLE
Update README.md

### DIFF
--- a/react-style-guide/README.md
+++ b/react-style-guide/README.md
@@ -71,9 +71,7 @@ class Foo extends React.Component {
     
     getBar() {
         if (this.props.hasBar) {
-            return (
-                <Bar />
-            );
+            return <Bar />;
         } else {
             return null;
         }
@@ -99,9 +97,7 @@ class Foo extends React.Component {
 
     getBar() {
         if (this.props.hasBar) {
-            return (
-                <Bar />
-            );
+            return <Bar />;
         } else {
             return null;
         }
@@ -133,9 +129,7 @@ class Foo extends React.Component {
 
     getBar() {
         if (this.props.hasBar) {
-            return (
-                <Bar />
-            );
+            return <Bar />;
         } else {
             return null;
         }


### PR DESCRIPTION
The parentheses are removed, since they are not needed for a single-line component and for clarity of explanation of the guide.