### PR TITLE
Add 'curly' rule

### DIFF
--- a/eslint-config-ringcentral-typescript/src/config.js
+++ b/eslint-config-ringcentral-typescript/src/config.js
@@ -15,6 +15,7 @@ module.exports = {
         'plugin:import/typescript',
     ],
     rules: {
+        'curly': 'error',
         'prettier/prettier': [
             'error',
             {


### PR DESCRIPTION
RC Style Guide contains 'Use brackets for all control constructs' rule, so it will be good to support this by ESlint